### PR TITLE
Enable Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -86,7 +86,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/check_install.sh
+++ b/check_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for version in 2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10;
+for version in 2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11;
 do
 if [ -a "`which python$version`" ]; then
 python$version << EOF

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ source_folder = {
     (3, 8): 'py34',
     (3, 9): 'py34',
     (3, 10): 'py34',
+    (3, 11): 'py34',
     }.get(version_info, None)
 if not source_folder:
     raise EnvironmentError("unsupported version of Python")
@@ -84,6 +85,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.11',
     ],
 
     setup_requires=setup_requirements,


### PR DESCRIPTION
## Summary
- support Python 3.11 in build matrix
- extend check_install script
- allow installation under Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffa8b71508330b3ce26d43893d75f