### PR TITLE
Expand README with installation and usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 # BACpypes
 
-BACpypes provides a BACnet application layer and network layer written in Python for daemons, scripting, and graphical interfaces.
-This is the current project, not the one over on SourceForge.
+BACpypes provides a BACnet application layer and network layer written in Python for daemons, scripting, and graphical interfaces. This is the current project, not the one over on SourceForge.
 
 [![Join the chat at https://gitter.im/JoelBender/bacpypes](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JoelBender/bacpypes?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Documentation Status](https://readthedocs.org/projects/bacpypes/badge/?version=latest)](http://bacpypes.readthedocs.io/en/latest/?badge=latest)
-  
+
+## Installation
+
+```bash
+pip install bacpypes
+```
+
+To use the latest code from GitHub:
+
+```bash
+git clone https://github.com/JoelBender/bacpypes.git
+cd bacpypes
+python setup.py install
+```
+
+## Usage
+
+Sample applications demonstrating common BACnet tasks can be found in the [`samples/`](samples) directory. For example, to see available options for the WhoIs/IAm example:
+
+```bash
+python samples/WhoIsIAm.py --help
+```
+
+## Documentation
+
+Extensive tutorials and guides are available in the [`doc/`](doc) directory or online at [Read the Docs](https://bacpypes.readthedocs.io/). The tutorials walk through getting started and explain each sample in detail.


### PR DESCRIPTION
## Summary
- add pip based installation instructions
- document cloning the repo and install from source
- note example usage of the samples
- link to documentation in the doc folder and on Read the Docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bacpypes')*
- `pip install -e .` *(fails: unsupported version of Python)*

------
https://chatgpt.com/codex/tasks/task_e_686418a7afa4833096227ce22f75b74f