### PR TITLE
Fix typo in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ source_folder = {
 if not source_folder:
     raise EnvironmentError("unsupported version of Python")
 if not os.path.exists(source_folder):
-    raise EnvironmentError("broken distirbution, looking for " +
+    raise EnvironmentError("broken distribution, looking for " +
         repr(source_folder) + " in " +
         os.getcwd()
         )


### PR DESCRIPTION
## Summary
- correct "broken distirbution" typo in `setup.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bacpypes')*
- `pip install -e .` *(fails: unsupported version of Python)*

------
https://chatgpt.com/codex/tasks/task_e_686418ac69fc83309ff60d366530f0c6