### PR TITLE
Update shebangs to env python3

### DIFF
--- a/py34/bacpypes/__init__.py
+++ b/py34/bacpypes/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """BACnet Python Package"""
 

--- a/py34/bacpypes/analysis.py
+++ b/py34/bacpypes/analysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Analysis - Decoding pcap files

--- a/py34/bacpypes/apdu.py
+++ b/py34/bacpypes/apdu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Application Layer Protocol Data Units

--- a/py34/bacpypes/app.py
+++ b/py34/bacpypes/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Application Module

--- a/py34/bacpypes/appservice.py
+++ b/py34/bacpypes/appservice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Application Layer

--- a/py34/bacpypes/basetypes.py
+++ b/py34/bacpypes/basetypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Base Types

--- a/py34/bacpypes/bsll.py
+++ b/py34/bacpypes/bsll.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACnet Streaming Link Layer Module

--- a/py34/bacpypes/bsllservice.py
+++ b/py34/bacpypes/bsllservice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACnet Streaming Link Layer Service

--- a/py34/bacpypes/bvll.py
+++ b/py34/bacpypes/bvll.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACnet Virtual Link Layer Module

--- a/py34/bacpypes/bvllservice.py
+++ b/py34/bacpypes/bvllservice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACnet Virtual Link Layer Service

--- a/py34/bacpypes/capability.py
+++ b/py34/bacpypes/capability.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Capability

--- a/py34/bacpypes/comm.py
+++ b/py34/bacpypes/comm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Communications Module

--- a/py34/bacpypes/commandlogging.py
+++ b/py34/bacpypes/commandlogging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Command Logging

--- a/py34/bacpypes/consolelogging.py
+++ b/py34/bacpypes/consolelogging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Console Logging

--- a/py34/bacpypes/constructeddata.py
+++ b/py34/bacpypes/constructeddata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Constructed Data

--- a/py34/bacpypes/core.py
+++ b/py34/bacpypes/core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Core

--- a/py34/bacpypes/debugging.py
+++ b/py34/bacpypes/debugging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Debugging

--- a/py34/bacpypes/errors.py
+++ b/py34/bacpypes/errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 #
 #   ConfigurationError

--- a/py34/bacpypes/iocb.py
+++ b/py34/bacpypes/iocb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 IOCB Module

--- a/py34/bacpypes/netservice.py
+++ b/py34/bacpypes/netservice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Network Service

--- a/py34/bacpypes/npdu.py
+++ b/py34/bacpypes/npdu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 NPDU

--- a/py34/bacpypes/object.py
+++ b/py34/bacpypes/object.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Object

--- a/py34/bacpypes/pdu.py
+++ b/py34/bacpypes/pdu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 PDU

--- a/py34/bacpypes/primitivedata.py
+++ b/py34/bacpypes/primitivedata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Primitive Data

--- a/py34/bacpypes/settings.py
+++ b/py34/bacpypes/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Settings

--- a/py34/bacpypes/singleton.py
+++ b/py34/bacpypes/singleton.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Singleton

--- a/py34/bacpypes/task.py
+++ b/py34/bacpypes/task.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Task

--- a/py34/bacpypes/tcp.py
+++ b/py34/bacpypes/tcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 """Minimal asyncio based TCP communications module."""
 
 import asyncio

--- a/py34/bacpypes/udp.py
+++ b/py34/bacpypes/udp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 UDP Communications Module

--- a/py34/bacpypes/vlan.py
+++ b/py34/bacpypes/vlan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Virtual Local Area Network

--- a/samples/HTTPServer.py
+++ b/samples/HTTPServer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 HTTPServer

--- a/samples/mini_device.py
+++ b/samples/mini_device.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 This sample application is a server that supports many core services that

--- a/samples/switch_demo.py
+++ b/samples/switch_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 """

--- a/sandbox/i_am_reject_test_x.py
+++ b/sandbox/i_am_reject_test_x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACpypes Test

--- a/sandbox/io.py
+++ b/sandbox/io.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 IO Module

--- a/sandbox/mutable_schedule_object.py
+++ b/sandbox/mutable_schedule_object.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Muteable Schedule Object

--- a/sandbox/read_property_reject_test_x.py
+++ b/sandbox/read_property_reject_test_x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACpypes Test

--- a/sandbox/switch_demo.py
+++ b/sandbox/switch_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 """

--- a/sandbox/threading_1.py
+++ b/sandbox/threading_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 This application demonstrates doing something at a regular interval.

--- a/sandbox/threading_2.py
+++ b/sandbox/threading_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 This application demonstrates doing something at a regular interval.

--- a/sandbox/threading_3.py
+++ b/sandbox/threading_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 This application demonstrates doing something at a regular interval.

--- a/sandbox/threading_4.py
+++ b/sandbox/threading_4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 This application demonstrates doing something at a regular interval.

--- a/sandbox/threading_5.py
+++ b/sandbox/threading_5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 This application demonstrates doing something at a regular interval.

--- a/sandbox/todo.py
+++ b/sandbox/todo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 To Do List

--- a/sandbox/who_is_reject_test_x.py
+++ b/sandbox/who_is_reject_test_x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACpypes Test

--- a/sandbox/xtest_io_client.py
+++ b/sandbox/xtest_io_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 test_io_client

--- a/sandbox/xtest_io_server.py
+++ b/sandbox/xtest_io_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test IO Server

--- a/sandbox/xtest_issue_45.py
+++ b/sandbox/xtest_issue_45.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 test_issue_45

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Glue routines to simulate package setup and teardown.

--- a/tests/extended_tag_list.py
+++ b/tests/extended_tag_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 ExtendedTagList

--- a/tests/state_machine.py
+++ b/tests/state_machine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Testing State Machine

--- a/tests/test_1.py
+++ b/tests/test_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/tests/test_apdu/__init__.py
+++ b/tests/test_apdu/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test BACpypes APDU Module

--- a/tests/test_base_types/__init__.py
+++ b/tests/test_base_types/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Base Types Module

--- a/tests/test_bvll/__init__.py
+++ b/tests/test_bvll/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test BVLL Module

--- a/tests/test_comm/__init__.py
+++ b/tests/test_comm/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test BACpypes Comm Module

--- a/tests/test_constructed_data/__init__.py
+++ b/tests/test_constructed_data/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Constructed Data Module

--- a/tests/test_constructed_data/helpers.py
+++ b/tests/test_constructed_data/helpers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Helper classes for constructed data tests.

--- a/tests/test_iocb/__init__.py
+++ b/tests/test_iocb/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test BACpypes IOCB Module

--- a/tests/test_local/__init__.py
+++ b/tests/test_local/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Local Schedule

--- a/tests/test_local/test_local_schedule_1.py
+++ b/tests/test_local/test_local_schedule_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Local Schedule

--- a/tests/test_network/__init__.py
+++ b/tests/test_network/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Network Discovery

--- a/tests/test_npdu/__init__.py
+++ b/tests/test_npdu/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Network Layer Encoding and Decoding

--- a/tests/test_pdu/__init__.py
+++ b/tests/test_pdu/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test BACpypes PDU Module

--- a/tests/test_primitive_data/__init__.py
+++ b/tests/test_primitive_data/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Primitive Data Module

--- a/tests/test_segmentation/__init__.py
+++ b/tests/test_segmentation/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Segmentation

--- a/tests/test_service/__init__.py
+++ b/tests/test_service/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Services

--- a/tests/test_utilities/__init__.py
+++ b/tests/test_utilities/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test Utilities

--- a/tests/test_vlan/__init__.py
+++ b/tests/test_vlan/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Test VLAN Networking

--- a/tests/time_machine.py
+++ b/tests/time_machine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Testing Time Machine

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 BACpypes Testing Utilities


### PR DESCRIPTION
## Summary
- use `/usr/bin/env python3` shebangs throughout
- make `samples/switch_demo.py` executable

## Testing
- `python3 setup.py test` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_686423cfe9408330ab0ac02ce53452a8