### PR TITLE
Use asyncio loop in core.run when available

### DIFF
--- a/py34/bacpypes/core.py
+++ b/py34/bacpypes/core.py
@@ -160,10 +160,10 @@ def run(spin=SPIN, sigterm=stop, sigusr1=print_stack):
 #           if _debug: run._debug("    - delta: %r", delta)
 
             # loop for socket activity or sleep for the delta
-            if asyncore:
-                asyncore.loop(timeout=delta, count=1)
-            elif asyncio:
+            if asyncio:
                 asyncio.get_event_loop().run_until_complete(asyncio.sleep(delta))
+            elif asyncore:
+                asyncore.loop(timeout=delta, count=1)
             else:
                 time.sleep(delta)
 


### PR DESCRIPTION
## Summary
- favor `asyncio` over `asyncore` in `core.run`
- this ensures that when an asyncio event loop is available it is used for sleeping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882825f40e88330ace137472468644d