### PR TITLE
Change debug file extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ coverage.xml
 
 # Django stuff:
 *.log
+*.debug
 
 # Sphinx documentation
 docs/_build/

--- a/test_script.sh
+++ b/test_script.sh
@@ -33,7 +33,7 @@ shift $((OPTIND-1))
 # this is where debugging output should go, the name of the
 # file matches the name of the script
 bugfile=$(basename $0)
-bugfile=${bugfile/.sh/.txt}
+bugfile=${bugfile/.sh/.debug}
 
 # debugging file can rotate, set the file size large to keep
 # it from rotating a lot


### PR DESCRIPTION
## Summary
- switch test debug output extension to `.debug`
- ignore `.debug` files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bc122844833087f28caac19c7c95